### PR TITLE
config: change grafana repo name to grafana-container

### DIFF
--- a/config/org.yaml
+++ b/config/org.yaml
@@ -52,12 +52,12 @@ orgs:
         description: Service to provide Ceph storage over NVMe-oF/TCP protocol
         has_issues: false
         has_projects: true
-      grafana:
+      grafana-container:
         allow_merge_commit: false
         allow_rebase_merge: true
         allow_squash_merge: false
         default_branch: release-8.1
-        description: rh container image for grafana from https://github.com/grafana/grafana
+        description: rh container image for grafana from https://github.com/ibmstorage/grafana
         has_projects: true
       haproxy:
         allow_merge_commit: false
@@ -195,7 +195,7 @@ orgs:
           ceph: write
           ceph-nvmeof: write
           haproxy: write
-          grafana: write
+          grafana-container: write
           keepalived: write
           org: write
           snmp-notifier: write

--- a/config/org.yaml
+++ b/config/org.yaml
@@ -94,7 +94,6 @@ orgs:
         allow_merge_commit: false
         allow_rebase_merge: true
         allow_squash_merge: false
-        default_branch: main
         has_projects: true
       jcadf:
         allow_merge_commit: false

--- a/config/org.yaml
+++ b/config/org.yaml
@@ -114,6 +114,13 @@ orgs:
         default_branch: main
         description: Meta configuration for IBM Storage Github Org
         has_projects: true
+      rhceph-container:
+        allow_merge_commit: false
+        allow_rebase_merge: true
+        allow_squash_merge: false
+        default_branch: main
+        description: Dockerfile for building rhceph container from https://pkgs.devel.redhat.com/cgit/containers/rhceph
+        has_projects: true
       samba:
         allow_merge_commit: false
         allow_rebase_merge: true
@@ -197,6 +204,7 @@ orgs:
           grafana-container: write
           keepalived: write
           org: write
+          rhceph-container: write
           snmp-notifier-container: write
           promtail: write
       samba-dev-team:

--- a/config/org.yaml
+++ b/config/org.yaml
@@ -166,7 +166,7 @@ orgs:
         default_branch: main
         description: Containerfiles and scripts for smbmetrics container builds
         has_projects: true
-      snmp-notifier:
+      snmp-notifier-container:
         allow_merge_commit: false
         allow_rebase_merge: true
         allow_squash_merge: false
@@ -197,7 +197,7 @@ orgs:
           grafana-container: write
           keepalived: write
           org: write
-          snmp-notifier: write
+          snmp-notifier-container: write
           promtail: write
       samba-dev-team:
         description: samba dev team


### PR DESCRIPTION
We want to fork upstream grafana into github.com/ibmstorage so rename this repo to avoid a conflict.